### PR TITLE
Added Bayelsa to the list for Nigeria, and with a correction on AkwaIbom

### DIFF
--- a/src/data-access/store/localities.store.ts
+++ b/src/data-access/store/localities.store.ts
@@ -200,10 +200,21 @@ export const localitiesStore: LocalityInterface[] = [
         children: [],
       },
       {
-        name: "Akwa Ibom",
+        name: "akwa ibom",
         zipCode: "520101",
         latitude: 4.990237,
         longitude: 7.9974399,
+        isCountry:false,
+        isState:true,
+        isCity:false,
+        alias:[],
+        children:[]
+      },
+      {
+        name: "bayelsa",
+        zipCode: "562101",
+        latitude: 4.7629786,
+        longitude: 6.028898,
         isCountry:false,
         isState:true,
         isCity:false,


### PR DESCRIPTION
Added Bayelsa to the list of Nigeria's child elements and as well corrected Akwa Ibom State's name to follow the naming convention of small letters instead of capital letters.